### PR TITLE
AppSettings, TranslateObject and ET_TriggeredSend

### DIFF
--- a/FuelSDK-CSharp/ET_Client.cs
+++ b/FuelSDK-CSharp/ET_Client.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
 using System.Text;
 using System.Reflection;
@@ -31,19 +32,28 @@ namespace FuelSDK
         public string SDKVersion = "FuelSDX-C#-V.8";
 
         //Constructor
-        public ET_Client(NameValueCollection parameters = null)
+        public ET_Client(NameValueCollection parameters = null, bool useAppSettings = false)
         {
-            //Get configuration file and set variables
-            System.Xml.XPath.XPathDocument doc = new System.Xml.XPath.XPathDocument(@"FuelSDK_config.xml");
-            foreach (System.Xml.XPath.XPathNavigator child in doc.CreateNavigator().Select("configuration"))
-            {
-                appSignature = child.SelectSingleNode("appSignature").Value.ToString().Trim();
-                clientId = child.SelectSingleNode("clientId").Value.ToString().Trim();
-                clientSecret = child.SelectSingleNode("clientSecret").Value.ToString().Trim();
-                soapEndPoint = child.SelectSingleNode("soapEndPoint").Value.ToString().Trim();
-            }         
-
-            //If JWT URL Parameter Used
+			if (useAppSettings)
+	        {
+		        appSignature = ConfigurationManager.AppSettings["FuelSDK.appSignature"];
+		        clientId = ConfigurationManager.AppSettings["FuelSDK.clientId"];
+		        clientSecret = ConfigurationManager.AppSettings["FuelSDK.clientSecret"];
+		        soapEndPoint = ConfigurationManager.AppSettings["FuelSDK.soapEndPoint"];
+	        }
+	        else
+	        {
+		        //Get configuration file and set variables
+		        System.Xml.XPath.XPathDocument doc = new System.Xml.XPath.XPathDocument(@"FuelSDK_config.xml");
+		        foreach (System.Xml.XPath.XPathNavigator child in doc.CreateNavigator().Select("configuration"))
+		        {
+			        appSignature = child.SelectSingleNode("appSignature").Value.ToString().Trim();
+			        clientId = child.SelectSingleNode("clientId").Value.ToString().Trim();
+			        clientSecret = child.SelectSingleNode("clientSecret").Value.ToString().Trim();
+			        soapEndPoint = child.SelectSingleNode("soapEndPoint").Value.ToString().Trim();
+		        }
+	        }
+	        //If JWT URL Parameter Used
             if (parameters != null && parameters.AllKeys.Contains("jwt"))
             {
                 string encodedJWT = parameters["jwt"].ToString().Trim();

--- a/FuelSDK-CSharp/FuelSDK-CSharp.csproj
+++ b/FuelSDK-CSharp/FuelSDK-CSharp.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FuelSDK</RootNamespace>
     <AssemblyName>CSharpSDK</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -40,9 +40,10 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=3.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>.\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.5.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Runtime.Serialization" />
@@ -70,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="FuelSDKKeyFile.pfx" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -79,6 +81,7 @@
     <WebReferences Include="Web References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/FuelSDK-CSharp/packages.config
+++ b/FuelSDK-CSharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="5.0.7" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
Added load settings from appSettings to make it easier to work with in web servers
Added JSON.net from nuget, 

Using ET_TriggeredSend uncovered an issue where ET_Subscribers had ET_ProfileAttributes, the ET_ProfileAttributes did not correctly translated to ProfileAttributes which caused a SOAP Exception. I changed TranslateObject to handle child objects/arrays.

Also changed ET_TriggeredSend.Send to not clear the Subscribers, this seems like an bad side effect if the caller wants to use them after.

Minor - updated to .NET 4