### PR TITLE
Contemplating FUEL API Sandbox URL when SOAP endpoint points to Sandbox

### DIFF
--- a/FuelSDK-CSharp/ET_Client.cs
+++ b/FuelSDK-CSharp/ET_Client.cs
@@ -90,7 +90,7 @@ namespace FuelSDK
                 //Get an internalAuthToken using clientId and clientSecret
                 string strURL = "https://auth.exacttargetapis.com/v1/requestToken?legacy=1";
 
-                // Change URL if SOAP endpoint points to a sandbox account
+                //Change URL if SOAP endpoint points to a sandbox account
                 if(soapEndPoint.ToLower().Contains("test"))
                     strURL = "https://auth-test.exacttargetapis.com/v1/requestToken?legacy=1";
 


### PR DESCRIPTION
For sandbox accounts, the SDK will return a 401 status when trying to retrieve a token since it's pointing to the production fuel API URL. I've made a small update to allow sandbox accounts to connect to the api.
