### PR TITLE
Create an interface for IET_Client to allow Unit Testing. 

### DIFF
--- a/FuelSDK-CSharp/ET_Client.cs
+++ b/FuelSDK-CSharp/ET_Client.cs
@@ -16,24 +16,27 @@ using System.ServiceModel.Channels;
 
 namespace FuelSDK
 {
-    public class ET_Client
+    public class ET_Client: IET_Client
     {
         //Variables
-        public string authToken;
-        public SoapClient soapclient;
+        public string authToken { get; set; }
+        public SoapClient soapclient { get; set; }
         private string appSignature = string.Empty;
         private string clientId = string.Empty;
         private string clientSecret = string.Empty;
         private string soapEndPoint = string.Empty;
         private string sandbox = string.Empty;
-        public string internalAuthToken = string.Empty;
+        public string internalAuthToken { get; set; }
         private string refreshKey = string.Empty;
         private DateTime authTokenExpiration = DateTime.Now;
-        public string SDKVersion = "FuelSDX-C#-V.9";
+        public string SDKVersion { get; set; }
 
         //Constructor
         public ET_Client(NameValueCollection parameters = null)
         {
+            internalAuthToken = string.Empty;
+            SDKVersion = "FuelSDX-C#-V.9";
+
             //Get configuration file and set variables
             if (File.Exists(@"FuelSDK_config.xml"))
             {
@@ -223,7 +226,7 @@ namespace FuelSDK
     {
         public ResultDetail[] Results { get; set; }
 
-        public PostReturn(APIObject[] theObjects, ET_Client theClient)
+        public PostReturn(APIObject[] theObjects, IET_Client theClient)
         {
             this.Message = "";
             this.Status = true;
@@ -2121,7 +2124,7 @@ namespace FuelSDK
     {
         [System.Xml.Serialization.XmlIgnore()]
         [JsonIgnore]
-        public FuelSDK.ET_Client AuthStub { get; set; }
+        public FuelSDK.IET_Client AuthStub { get; set; }
         [System.Xml.Serialization.XmlIgnore()]
         public string[] Props { get; set; }
         [System.Xml.Serialization.XmlIgnore()]

--- a/FuelSDK-CSharp/FuelSDK-CSharp.csproj
+++ b/FuelSDK-CSharp/FuelSDK-CSharp.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="ET_Client.cs" />
     <Compile Include="ExactTargetSOAP.cs" />
+    <Compile Include="IET_Client.cs" />
     <Compile Include="JWT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Settings.Designer.cs">

--- a/FuelSDK-CSharp/IET_Client.cs
+++ b/FuelSDK-CSharp/IET_Client.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FuelSDK
+{
+    public interface IET_Client
+    {
+        string authToken { get; set; }
+        SoapClient soapclient { get; set; }
+        string internalAuthToken { get; set; }
+        string SDKVersion { get; set; }
+
+        void refreshToken(bool force = false);
+        FuelReturn AddSubscribersToList(string EmailAddress, string SubscriberKey, List<int> ListIDs);
+        FuelReturn AddSubscribersToList(string EmailAddress, List<int> ListIDs);
+        FuelReturn CreateDataExtensions(ET_DataExtension[] ArrayOfET_DataExtension);
+    }
+}


### PR DESCRIPTION
ET_Client will make a Soap request in it's contrustor, this doesn't allow for construction of ET_Client with out an external call. This restricts the ability of creating Unit Tests around ET_Triggered Send Objects. 

By creating IET_Client, changing to definition of AuthSub on APIObject to IET_Client, and implementing IET_Client on ET_Client allows ET_TriggeredSend to be unit testable.
