### PR TITLE
W-5871581 Fix stack key property usage in ETClient's constructor

### DIFF
--- a/FuelSDK-CSharp/ETClient.cs
+++ b/FuelSDK-CSharp/ETClient.cs
@@ -20,7 +20,7 @@ namespace FuelSDK
     /// </summary>
     public class ETClient
     {
-        public const string SDKVersion = "FuelSDK-C#-v1.1.0";
+        public const string SDKVersion = "FuelSDK-C#-v1.1.1";
 
         private FuelSDKConfigurationSection configSection;
         public string AuthToken { get; private set; }

--- a/FuelSDK-Test/ETClientTest.cs
+++ b/FuelSDK-Test/ETClientTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
+using System.Collections.Specialized;
 using System.Reflection;
 
 namespace FuelSDK.Test
@@ -15,14 +16,6 @@ namespace FuelSDK.Test
         {
             client1 = new ETClient();
             client2 = new ETClient();
-        }
-
-        [Test()]
-        public void GetClientStack()
-        {
-            Assert.IsNotNull(client1.Stack);
-            Assert.IsNotNull(client2.Stack);
-            Assert.AreEqual(client1.Stack, client2.Stack);
         }
 
         [Test()]

--- a/FuelSDK-Test/ETClientTest.cs
+++ b/FuelSDK-Test/ETClientTest.cs
@@ -1,6 +1,5 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Collections.Specialized;
 using System.Reflection;
 
 namespace FuelSDK.Test

--- a/FuelSDK-Test/StackKeyTest.cs
+++ b/FuelSDK-Test/StackKeyTest.cs
@@ -1,19 +1,35 @@
 ﻿using NUnit.Framework;
+using System;
+using System.Linq;
 
 namespace FuelSDK.Test
 {
     [TestFixture]
     public class StackKeyTest
     {
-        [Test]
-        public void MultipleETClientInstancesForTheSameClientIdAndSecretWillHaveTheSameStackKey()
-        {
-            ETClient client1 = new ETClient();
-            ETClient client2 = new ETClient();
+        private const string StackKeyErrorMessage = "Tenant specific endpoints doesn't support Stack Key property and this will property will be deprecated in next major release";
 
-            Assert.IsNotNull(client1.Stack);
-            Assert.IsNotNull(client2.Stack);
-            Assert.AreEqual(client1.Stack, client2.Stack);
+        [Test]
+        public void ExceptionOccursIfTSEFormatIsUsedForSoapEndpoint()
+        {
+            var client = new ETClient();
+
+            var exception = Assert.Throws<Exception>(
+                () => { var stack = client.Stack; }
+            );
+
+            Assert.That(exception.Message, Is.EqualTo(StackKeyErrorMessage));
+        }
+
+        [Test]
+        public void StackPropertyIsMarkedAsObsolete()
+        {
+            var type = typeof(ETClient);
+            var obsoleteAttributes = (ObsoleteAttribute[])type.GetProperty("Stack").GetCustomAttributes(typeof(ObsoleteAttribute), false);
+
+            Assert.AreEqual(1, obsoleteAttributes.Length);
+            Assert.AreEqual(StackKeyErrorMessage, obsoleteAttributes[0].Message);
+            Assert.AreEqual(false, obsoleteAttributes[0].IsError);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Salesforce Marketing Cloud Fuel SDK for C#
 ## Overview ##
 The Fuel SDK for C# provides easy access to Salesforce Marketing Cloud's Fuel API Family services, including a collection of REST APIs and a SOAP API. These APIs provide access to Salesforce Marketing Cloud functionality via common collection types. 
 
+## Latest Version 1.1.1 ##
+* Bug fixes
+
 ## New Features in Version 1.1.0 ##
 * **Added support for your tenant's endpoints - [More Details](https://developer.salesforce.com/docs/atlas.en-us.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm) :** The user of the SDK can now configure them through a **App.config** file OR using the “**parameters**” **ETClient** constructor parameter as in the previous version of the SDK. The user of the SDK has to make a copy of the **App.config.transform** file which is found in the **FuelSDK-CSharp** folder, place it in the same folder and rename it to **App.config**. The structure of this file will be the following: 
 

--- a/nuspecs/FuelSDK-CSharp.nuspec
+++ b/nuspecs/FuelSDK-CSharp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>SFMC.FuelSDK</id>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <title>FuelSDK-CSharp</title>
     <authors>Salesforce</authors>
     <owners>Salesforce</owners>


### PR DESCRIPTION
Revert back to the way the Stack key was determined from the SOAP endpoint. Moved the logic to parse the SOAP endpoint in the Stack property getter - exception will occur only if the Stack property is used. Added unit tests.