### PR TITLE
correct DataExtensionField retrieval code sample

### DIFF
--- a/objsamples/Sample_DataExtension.cs
+++ b/objsamples/Sample_DataExtension.cs
@@ -72,7 +72,7 @@ namespace objsamples
                 {
                     AuthStub = myclient,
                     Props = new[] { "Name", "FieldType" },
-                    SearchFilter = new SimpleFilterPart { Property = "DataExtension.CustomerKey", SimpleOperator = SimpleOperators.equals, Value = new[] { nameOfTestDataExtension } },
+                    SearchFilter = new SimpleFilterPart { Property = "DataExtensionField.DataExtension.CustomerKey", SimpleOperator = SimpleOperators.equals, Value = new[] { nameOfTestDataExtension } },
                 };
                 var getColumnResponse = getColumn.Get();
                 Console.WriteLine("Get Status: " + getColumnResponse.Status.ToString());


### PR DESCRIPTION
`DataExtension.CustomerKey` is not a valid property. `DataExtensionField.DataExtension.CustomerKey` is the proper field to use when filtering on CustomerKey.